### PR TITLE
Optionally use IntEnums to set loglvl

### DIFF
--- a/slog/__init__.py
+++ b/slog/__init__.py
@@ -1,11 +1,22 @@
 #!/usr/bin/python
 # coding=utf8
 
+import enum
 import logging
 
 from inspect import currentframe, getframeinfo
 from time import strftime, sleep
 from termcolor import colored
+
+
+class LogLevel(enum.IntEnum):
+    none = 0
+    crit = 1
+    fail = 2
+    warn = 3
+    info = 4
+    ok = 5
+
 
 def ct():
     return strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Adds functionality to use an IntEnum subclass to set `loglvl`, rather than have to set an actual int.
The IntEnum subclass has the same attributes as slog's logging methods, which makes it easier to set the appropriate level.
The use of IntEnum is effectively an abstraction over the (old) int-style log levels, which makes this feature backwards compatible